### PR TITLE
Extend documentation to embed Vault into kubeconfig

### DIFF
--- a/website/content/docs/secrets/kubernetes.mdx
+++ b/website/content/docs/secrets/kubernetes.mdx
@@ -257,6 +257,50 @@ $ curl -sk $(kubectl config view --minify -o 'jsonpath={.clusters[].cluster.serv
 }
 ```
 
+## Kubectl integration
+
+You can also bake the kubernetes token generation via the [ExecConfig](https://kubernetes.io/docs/reference/config-api/kubeconfig.v1/#ExecConfig) mechanism directly into the kubeconfig file. Due to the output format of Vault needs to be adapted to match the Kubernetes schema, this mechanism will require `jq` or a similar transformation tool.
+
+```yaml
+---
+apiVersion: v1
+kind: Config
+preferences: {}
+clusters:
+- cluster:
+    certificate-authority-data: ***
+    server: https://***
+  name: cluster
+contexts:
+- name: context
+  context:
+    cluster: cluster
+    user: user
+current-context: context
+users:
+- name: user
+  user:
+    exec:
+      apiVersion: "client.authentication.k8s.io/v1beta1"
+      command: bash
+      args:
+        - -c
+        - >
+          vault write -format=json kubernetes/creds/my-role | jq -r '{apiVersion: "client.authentication.k8s.io/v1beta1", status: {token: .data.service_account_token}}'
+```
+
+As a result, you can call `kubectl` directly:
+
+```shell-session
+$ export VAULT_ADDR=***
+$ export VAULT_TOKEN=$(vault login -token-only -method=ldap username=***)
+$ export KUBECONFIG=kubeconfig.yml
+
+$ kubectl get namespaces
+```
+
+~> **Note**: While this method will query Vault for a new token with every `kubectl` call, the recommendation is to use it only with a configuration where Vault is generating the Kubernetes token only, so the overhead on dynamic elements created inside your cluster stays minimal.
+
 ## TTL
 
 Kubernetes service account tokens have a time-to-live (TTL). When a token expires it is


### PR DESCRIPTION
### Description
This PR extends the documentation on how to dynamically generate Kubernets tokens by Vault in a quiet user friendly way.

It solves hashicorp/vault#30973 by converting the token coming from Vault via `jq` and inject it directly into the context of `kubectl`. By this, the whole token generation mechanism can be hidden from the user by including everything needed within the `kubeconfig` file itself.